### PR TITLE
Refactor: Unify field node colors in editor

### DIFF
--- a/src/components/editor/extensions/FieldNameNode.ts
+++ b/src/components/editor/extensions/FieldNameNode.ts
@@ -19,7 +19,7 @@ export const FieldNameNode = Node.create<FieldNameOptions>({
   addOptions() {
     return {
       HTMLAttributes: {
-        class: 'field-name-node bg-muted hover:bg-secondary p-1 rounded-sm border border-input mx-0.5 text-foreground cursor-pointer transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1',
+        class: 'field-name-node bg-accent hover:bg-primary/80 p-1 rounded-sm border border-input mx-0.5 text-accent-foreground cursor-pointer transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1',
       },
     };
   },


### PR DESCRIPTION
I've updated the styling for `FieldNameNode` (standard fields) to match the color scheme of `MultiOptionNode` (multi-option fields) within your report editor.

Changes include:
- Background color changed from `bg-muted` to `bg-accent`.
- Text color changed from `text-foreground` to `text-accent-foreground`.
- Hover background color changed from `hover:bg-secondary` to `hover:bg-primary/80`.

This change ensures a consistent visual appearance for different types of interactive fields in your editor.